### PR TITLE
Grammar correction on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ author: azumakuniyuki
                         lib<span>sisimai</span>.org
                     </h1>
                     <p class = 'animated fadeInRightBig'>
-                        <strong>{{ site.html.ss }}</strong> | Mail Analyzing Interface | Parse Every Email Bounces
+                        <strong>{{ site.html.ss }}</strong> | Mail Analyzing Interface | Parse Every Email Bounce
                     </p>
                     <a data-scroll class = 'btn btn-start animated fadeInUpBig' href = '/en'>
                         <span class = 'uk24'></span><br>English


### PR DESCRIPTION
`Parse Every Email Bounces` reads incorrectly as `every` is a "distributive determiner" or "indefinite determiner" which enumerates over a group (in this case, the set of email bounces).

See: [here](http://www.ef.com/english-resources/english-grammar/using-each-and-every/) & [here](https://en.wikipedia.org/wiki/English_determiners#Common_determiners).

This PR proposes the change to `Parse Every Email Bounce`, however, a correct alternative would be to say `Parse All Email Bounces`.

Thanks for sharing this project. I'm quite enjoying playing with it :)